### PR TITLE
remove the entry only when known_hosts file exists

### DIFF
--- a/init
+++ b/init
@@ -14,7 +14,7 @@ ln -sf $(vagrant ssh-config | grep IdentityFile | awk '{print $2}' | sed -e 's/^
 HOST=$(vagrant ssh-config | grep HostName | awk '{print $2}')
 popd
 
-ssh-keygen -R ${HOST}
+test -e ~/.ssh/known_hosts && ssh-keygen -R ${HOST}
 ssh -i private_key -oStrictHostKeyChecking=no vagrant@${HOST} :
 
 # ktest setting (host)


### PR DESCRIPTION
ssh-keygen -R fails when ~/.ssh/known_hosts is missing and cause the init script to fail.
This patch adds an extra check to prevent such failure.